### PR TITLE
fix: 修复评论组件问题

### DIFF
--- a/module/comment.ftl
+++ b/module/comment.ftl
@@ -1,8 +1,8 @@
 <#--评论功能OK-->
-<#macro comment post,type>
+<#macro comment target,type>
     <#if !post.disallowComment!false>
         <script src="https://cdn.bootcss.com/vue/2.6.10/vue.min.js"></script>
         <script src="${options.comment_internal_plugin_js!'//cdn.jsdelivr.net/gh/halo-dev/halo-comment@latest/dist/halo-comment.min.js'}"></script>
-        <halo-comment id="${post.id}" type="${type}"/>
+        <halo-comment id="${target.id?c}" type="${type}"/>
     </#if>
 </#macro>


### PR DESCRIPTION
当文章 id 为 1000+ 的时候会解析错误。

如：1001 会 解析为 1,001。那么在这个时候 id 是无法正确获取的。