### PR TITLE
修复content内a标签没有href属性时报错问题

### DIFF
--- a/source/js/post.js
+++ b/source/js/post.js
@@ -369,7 +369,8 @@ $(function () {
 
     // 初始化处理，在新标签中打开页面
     linkOnBlackPage && $("#content a").filter(function () {
-        let isLinkToCurrentPage = $(this).attr("href").startsWith("#");
+        let titleId = $(this).attr("href");
+        let isLinkToCurrentPage = titleId && titleId.startsWith("#");
         // 给每个链接到当前页面的链接一个点击事件，通过动画滚动到目标位置
         isLinkToCurrentPage && $(this).on('click', function (event) {
             let titleId = $(this).attr("href");


### PR DESCRIPTION
当使用a标签当锚点时，其href属性值为undefined。此时会导致js报错而缺失目录和相关功能
![image](https://user-images.githubusercontent.com/32292315/136648839-2f017be4-b407-4478-b888-5bf5594364c1.png)
